### PR TITLE
Fix GNOME 45/46 compatibility: replace Clutter.Orientation enum with …

### DIFF
--- a/noResults.js
+++ b/noResults.js
@@ -7,7 +7,7 @@ import Clutter from 'gi://Clutter';
 // creates the empty state widget shown when search returns nothing
 export function buildNoResults(query) {
     const box = new St.BoxLayout({
-        orientation: Clutter.Orientation.VERTICAL,
+        vertical: true,
         style_class: 'spotlight-no-results',
     });
     box.add_child(new St.Label({

--- a/resultRow.js
+++ b/resultRow.js
@@ -8,7 +8,7 @@ import Clutter from 'gi://Clutter';
 export function buildResultRow(result, resultIndex, onActivate, onHover) {
     const hbox = new St.BoxLayout({
         style_class: 'spotlight-result',
-        orientation: Clutter.Orientation.HORIZONTAL,
+        vertical: false,
         reactive: true,
         can_focus: true,
         track_hover: true,
@@ -31,7 +31,7 @@ export function buildResultRow(result, resultIndex, onActivate, onHover) {
 
     const text = new St.BoxLayout({
         style_class: 'spotlight-result-content',
-        orientation: Clutter.Orientation.VERTICAL,
+        vertical: true,
         y_align: Clutter.ActorAlign.CENTER,
         x_expand: true,
     });

--- a/resultsContainer.js
+++ b/resultsContainer.js
@@ -14,7 +14,7 @@ export function buildResultsContainer() {
         x_expand: true,
     });
     const resultsBox = new St.BoxLayout({
-        orientation: Clutter.Orientation.VERTICAL,
+        vertical: true,
         x_expand: true,
         y_expand: true,
     });

--- a/searchEntry.js
+++ b/searchEntry.js
@@ -7,7 +7,7 @@ import Clutter from 'gi://Clutter';
 // builds the search entry box with icon and text field
 export function buildSearchEntry() {
     const entryBox = new St.BoxLayout({
-        orientation: Clutter.Orientation.HORIZONTAL,
+        vertical: false,
         x_expand: true,
         style_class: 'spotlight-entry-box',
     });

--- a/spotlightPopup.js
+++ b/spotlightPopup.js
@@ -30,13 +30,15 @@ export const SpotlightPopup = GObject.registerClass(
 class SpotlightPopup extends St.BoxLayout {
     _init(extension) {
         super._init({
-            orientation: Clutter.Orientation.VERTICAL,
             style_class: 'spotlight-container',
             reactive: true,
             can_focus: true,
             visible: false,
             width: extension._settings.get_int('popup-width'),
         });
+        // orientation set after init for gnome 45/46 compatibility
+        // the Clutter.Orientation enum property was added in gnome 47
+        this.set_vertical(true);
 
         this._settings = extension._settings;
         this._results = [];


### PR DESCRIPTION
…vertical boolean

The Clutter.Orientation enum-based 'orientation' property on St.BoxLayout was introduced in GNOME 47. For GNOME 45 and 46, St.BoxLayout uses the boolean 'vertical' property instead.

Changes (minimal - keyboard handler untouched):
- spotlightPopup.js: subclass - call set_vertical(true) after super._init()
- searchEntry.js: vertical: false (was HORIZONTAL)
- resultsContainer.js: vertical: true (was VERTICAL)
- resultRow.js: vertical: false + vertical: true
- noResults.js: vertical: true (was VERTICAL)

The 'vertical' property works in all supported versions 45-50, while 'orientation' only works in 47+. This fixes GitHub issue #5.

## Description

Briefly describe what this PR changes and why.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code style cleanup

## Checklist

- [x] Comments are lowercase with no punctuation (unless meaning requires it)
- [x] No `try`/`catch` around standard API calls
- [x] No `?.` or `??` for guaranteed methods
- [x] `enable()` and `disable()` are adjacent
- [x] All objects created in `enable()` are destroyed in `disable()`
- [x] Signals use `connectObject()` (except `global.display`/`global.stage`)
- [x] No module-scope instances, signals, or main-loop sources
- [x] Shell files don't import `Gtk`/`Gdk`/`Adw`
- [x] Prefs files don't import `St`/`Clutter`/`Meta`/`Shell`
- [x] Tested on GNOME Shell 50 Wayland
- [x] All JS files parse as ES modules

## Testing

How did you test? Which GNOME Shell versions?
