### PR TITLE
Fix #17: Use -st-icon-style: requested instead of symbolic

### DIFF
--- a/skills/extension-styling/SKILL.md
+++ b/skills/extension-styling/SKILL.md
@@ -22,3 +22,9 @@ dark light detection via org.gnome.desktop.interface color-scheme
 use rgba colors for background to achieve glass effect rgba r g b a
 true background blur requires complex shaders or gnome 51 ext background effect protocol
 alpha 0.80 to 0.90 balances glass feel with readability
+## st icon style
+-st-icon-style values verified via official gnome st docs
+requested use icon natural style default behavior
+regular force full color even for symbolic names
+symbolic force symbolic even for regular names
+never force symbolic globally it breaks gnome core app icons

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -8,7 +8,7 @@
   border: none;
   outline: none;
   box-shadow: none;
-  -st-icon-style: symbolic;
+  -st-icon-style: requested;
 }
 /* container - single unified window dark default */
 .spotlight-container {


### PR DESCRIPTION
Issue #17: GNOME-specific apps showed symbolic icons instead of full-color.

Root cause: stylesheet.css forced -st-icon-style: symbolic globally on .spotlight-container *. This forced ALL icons to symbolic variants.

Why only GNOME apps: GNOME core apps ship both symbolic and full-color icon variants. Third-party apps (Chrome, VS Code, Ghostty) typically only ship full-color icons, so forcing symbolic on them falls through to full-color.

Fix: Change symbolic -> requested. ST_ICON_STYLE_REQUESTED respects each icon's natural style. Search provider category headers (created as symbolic) stay symbolic. App icons (created as regular/full-color) display correctly.

Verified via official GNOME St documentation:
https://gnome.pages.gitlab.gnome.org/gnome-shell/st/enum.IconStyle.html

Skill updated: extension-styling documents st-icon-style values.

## Description

Briefly describe what this PR changes and why.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code style cleanup

## Checklist

- [ ] Comments are lowercase with no punctuation (unless meaning requires it)
- [ ] No `try`/`catch` around standard API calls
- [ ] No `?.` or `??` for guaranteed methods
- [ ] `enable()` and `disable()` are adjacent
- [ ] All objects created in `enable()` are destroyed in `disable()`
- [ ] Signals use `connectObject()` (except `global.display`/`global.stage`)
- [ ] No module-scope instances, signals, or main-loop sources
- [ ] Shell files don't import `Gtk`/`Gdk`/`Adw`
- [ ] Prefs files don't import `St`/`Clutter`/`Meta`/`Shell`
- [ ] No JS-only properties (like `_entry`, `_data`) in GObject constructors — assign with `item._prop = value` after construction
- [ ] Tested on GNOME Shell 50 Wayland
- [ ] All JS files parse as ES modules

## Testing

How did you test? Which GNOME Shell versions?
