### PR TITLE
Fix black screen when typing in Spotlight while overview is visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@ A transparent full-screen St widget sits in the chrome layer behind the popup. T
 
 Workspace thumbnails in the overview are intentionally small by default. Spotlight increases _maxThumbnailScale from its default to 0.1, effectively doubling the maximum available size so thumbnails are actually usable on modern high-resolution displays. Applied to both the primary monitor thumbnails box and the SecondaryMonitorDisplay prototype method _getThumbnailsHeight for multi-monitor setups. Original values are backed up in stealOverviewSearch and restored in returnOverviewSearch.
 
+## Overview Type-to-Search Interception
+
+The GNOME overview has a start-typing-to-search feature that activates on any printable key press at the stage level. Since Spotlight permanently steals the overview search widgets, this feature would cause a black screen by trying to render results in widgets that no longer exist in the overview hierarchy. The fix intercepts printable keys at the stage captured-event level whenever the overview is visible. When the popup is closed, keys are simply consumed. When the popup is open, the event is forwarded to the entry manually via entry.event(event) before returning EVENT_STOP, ensuring the overview handler never sees the key while our entry still receives it.
+
 ## Popup Close Mechanisms
 
 The popup closes on toggle shortcut, Escape or click outside, plus a comprehensive activation-close defense. First, button-press-event on the search results catches mouse clicks on any result. Second, Enter or Space key capture when focus sits on result buttons rather than the entry. Third, global.display notify::focus-window tracks external app focus at the window manager level.

--- a/lib/ui/spotlightPopup.js
+++ b/lib/ui/spotlightPopup.js
@@ -150,21 +150,29 @@ class SpotlightPopup extends St.Widget {
         }
 
         // The overview and app grid have a start-typing-to-search feature. Since we
-        // permanently stole the search widgets this would just show a blank screen. We intercept printable keys at stage level before the overview sees them and consume them so nothing happens. We only do this when the overview is visible and our popup is not. Non-printable keys pass through normally.
+        // permanently stole the search widgets this would just show a blank screen.
+        // We intercept printable keys at stage level before the overview sees them.
+        // When our popup is closed, we consume them so nothing happens. When our popup
+        // is open, we forward the key to our entry manually and then stop propagation
+        // so the overview handler, which connected earlier and fires first in the
+        // capture chain, never gets a chance to react.
         if (this._overviewKeyCaptureId === 0) {
             this._overviewKeyCaptureId = global.stage.connect(
                 'captured-event',
                 (actor, event) => {
                     if (event.type() !== Clutter.EventType.KEY_PRESS)
                         return Clutter.EVENT_PROPAGATE;
-                    if (!Main.overview.visible || this._visible)
+                    if (!Main.overview.visible)
                         return Clutter.EVENT_PROPAGATE;
                     const unicode = Clutter.keysym_to_unicode(
                         event.get_key_symbol(),
                     );
                     // Unicode 0x20 and above are printable. Control characters pass through.
-                    if (unicode >= 0x20)
+                    if (unicode >= 0x20) {
+                        if (this._visible && this._entry)
+                            this._entry.event(event);
                         return Clutter.EVENT_STOP;
+                    }
                     return Clutter.EVENT_PROPAGATE;
                 },
             );

--- a/skills/extension-best-practices/SKILL.md
+++ b/skills/extension-best-practices/SKILL.md
@@ -72,3 +72,7 @@ primary monitor thumbnails box and the SecondaryMonitorDisplay prototype method
 _getThumbnailsHeight for multi-monitor setups. Always back up the original values
 in enable and restore them in disable.
 
+## Overview Type-to-Search Interception
+
+The GNOME overview has a start-typing-to-search feature that activates on any printable key press at the stage level. When an extension permanently steals the overview search widgets, this feature causes a black screen because it tries to render results in widgets that no longer exist in the overview hierarchy. The fix requires intercepting printable keys at the stage captured-event level. However, the overview handler connects earlier and fires first in the capture chain. Simply consuming the event works when the popup is closed, but when the popup is open the entry needs to receive the key. The solution is to always intercept printable keys when the overview is visible, and when the popup is open, manually forward the event to the entry via entry.event(event) before returning EVENT_STOP. This prevents the overview handler from ever seeing the key while ensuring the popup entry still receives it.
+


### PR DESCRIPTION
## Description

Briefly describe what this PR changes and why.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code style cleanup

## Checklist

- [ ] Comments are natural, human style : capitals where they make sense, light punctuation
- [ ] No `try`/`catch` around standard API calls
- [ ] No `?.` or `??` for guaranteed methods
- [ ] `enable()` and `disable()` are adjacent
- [ ] All objects created in `enable()` are destroyed in `disable()`
- [ ] Signals use `connectObject()` (except `global.display`/`global.stage`)
- [ ] No module-scope instances, signals, or main-loop sources
- [ ] Shell files don't import `Gtk`/`Gdk`/`Adw`
- [ ] Prefs files don't import `St`/`Clutter`/`Meta`/`Shell`
- [ ] No JS-only properties (like `_entry`, `_data`) in GObject constructors : assign with `item._prop = value` after construction
- [ ] Tested on GNOME Shell 50 Wayland
- [ ] All JS files parse as ES modules

## Testing

How did you test? Which GNOME Shell versions?
